### PR TITLE
fix redirection typo to ${LOG}

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -3,21 +3,21 @@
 utils.lxc.attach() {
   cmd="$@"
   log "Running [${cmd}] inside '${CONTAINER}' container..."
-  (lxc-attach -n ${CONTAINER} -- $cmd) & >> ${LOG}
+  (lxc-attach -n ${CONTAINER} -- $cmd) &>> ${LOG}
 }
 
 utils.lxc.start() {
-  lxc-start -d -n ${CONTAINER} & >> ${LOG} || true
+  lxc-start -d -n ${CONTAINER} &>> ${LOG} || true
 }
 
 utils.lxc.stop() {
-  lxc-stop -n ${CONTAINER} & >> ${LOG} || true
+  lxc-stop -n ${CONTAINER} &>> ${LOG} || true
 }
 
 utils.lxc.destroy() {
-  lxc-destroy -n ${CONTAINER} & >> ${LOG}
+  lxc-destroy -n ${CONTAINER} &>> ${LOG}
 }
 
 utils.lxc.create() {
-  lxc-create -n ${CONTAINER} "$@" & >> ${LOG}
+  lxc-create -n ${CONTAINER} "$@" &>> ${LOG}
 }


### PR DESCRIPTION
This commit fixes the redirection of std error to the ${LOG} file.
It was starting all lxc command in background, resulting in unpredictable failures.
