### PR TITLE
add additional package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /log
 /output
+*_packages

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ make precise
 Will build a Ubuntu Precise x86_64 box with latest Puppet, Chef, Salt and
 Babushka pre-installed.
 
+```sh
+ADDPACKAGES="aptitude htop" \
+make trusty
+```
+
+Will build a Ubuntu Trusty x86_64 box with aptitude and htop as additional
+packages pre-installed. You can also specify the packages in a file
+trusty_packages.
 
 ## Pre built base boxes
 

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -14,8 +14,11 @@ SECS=15
 log "Sleeping for $SECS seconds..."
 sleep $SECS
 
-# TODO: Support for appending to this list from outside
 PACKAGES=(vim curl wget man-db openssh-server bash-completion python-software-properties ca-certificates sudo)
+
+log "Installing additional packages: ${ADDPACKAGES}"
+PACKAGES+=" ${ADDPACKAGES}"
+
 if [ $DISTRIBUTION = 'ubuntu' ]; then
   PACKAGES+=' software-properties-common'
 fi

--- a/mk-debian.sh
+++ b/mk-debian.sh
@@ -13,6 +13,7 @@ export RELEASE=$2
 export ARCH=$3
 export CONTAINER=$4
 export PACKAGE=$5
+export ADDPACKAGES=${ADDPACKAGES-$(cat ${RELEASE}_packages | tr "\n" " ")}
 export ROOTFS="/var/lib/lxc/${CONTAINER}/rootfs"
 export WORKING_DIR="/tmp/${CONTAINER}"
 export NOW=$(date -u)


### PR DESCRIPTION
I've seen the TODO in the source and needed the feature anyway. I thought an environment variable would be best to implement this. I also added the option to have a package-file per release to specify additional lists of packages.
