### PR TITLE
fix comparing string to a number

### DIFF
--- a/common/download.sh
+++ b/common/download.sh
@@ -39,7 +39,7 @@ elif [ ${DISTRIBUTION} = 'fedora' -a "${RELEASE}" = 'rawhide' ]; then
   utils.lxc.create -t fedora --\
                    --release ${RELEASE} \
                    --arch ${ARCH}
-elif [ ${DISTRIBUTION} = 'fedora' -a ${RELEASE} -ge 21 ]; then
+elif [[ ( ${DISTRIBUTION} = 'fedora' ) && ( ${RELEASE} -ge 21 ) ]]; then
   ARCH=$(echo ${ARCH} | sed -e "s/38/68/" | sed -e "s/amd64/x86_64/")
   utils.lxc.create -t fedora --\
                    --release ${RELEASE} \


### PR DESCRIPTION
As it is the `-a` operator evaluates both conditions and thus will fail when `${RELEASE}` variable is a string. When operator `&&` is used, the second condition won't be evaluated.
