### PR TITLE
Passwd aging on CentOS

### DIFF
--- a/common/download.sh
+++ b/common/download.sh
@@ -39,7 +39,7 @@ elif [ ${DISTRIBUTION} = 'fedora' -a "${RELEASE}" = 'rawhide' ]; then
   utils.lxc.create -t fedora --\
                    --release ${RELEASE} \
                    --arch ${ARCH}
-elif [ ${DISTRIBUTION} = 'fedora' -a ${RELEASE} -ge 21 ]; then
+elif [[ ( ${DISTRIBUTION} = 'fedora' ) && ( ${RELEASE} -ge 21 ) ]]; then
   ARCH=$(echo ${ARCH} | sed -e "s/38/68/" | sed -e "s/amd64/x86_64/")
   utils.lxc.create -t fedora --\
                    --release ${RELEASE} \

--- a/common/prepare-vagrant-user.sh
+++ b/common/prepare-vagrant-user.sh
@@ -22,6 +22,12 @@ elif [ ${DISTRIBUTION} = 'centos' -o ${DISTRIBUTION} = 'fedora' ]; then
   chroot ${ROOTFS} useradd --create-home -s /bin/bash -u 1000 vagrant &>> ${LOG}
   echo -n 'vagrant:vagrant' | chroot ${ROOTFS} chpasswd
   sed -i 's/^Defaults\s\+requiretty/# Defaults requiretty/' $ROOTFS/etc/sudoers
+  if [ ${RELEASE} -eq 6 ]; then
+    info 'Disabling password aging for root...'
+    # disable password aging (required on Centos 6)
+    # pretend that password was changed today (won't fail during provisioning)
+    chroot ${ROOTFS} chage -I -1 -m 0 -M 99999 -E -1 -d `date +%Y-%m-%d` root
+  fi
 else
   debug 'Creating vagrant user...'
   chroot ${ROOTFS} useradd --create-home -s /bin/bash vagrant &>> ${LOG}


### PR DESCRIPTION
Provisioning CentOS ends with message:

```
Password change required but no TTY available
```

This patch pretends that password was changed today (day of building image).
