### PR TITLE
Allow running a provisioner script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ centos: $(CENTOS_BOXES)
 fedora: $(FEDORA_BOXES)
 
 # REFACTOR: Figure out how can we reduce duplicated code
-$(UBUNTU_BOXES): CONTAINER = "vagrant-base-${@}-$(ARCH)"
-$(UBUNTU_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-$(ARCH).box"
+$(UBUNTU_BOXES): CONTAINER = "vagrant-base-${@}-$(ARCH)$(BOX_SUFFIX)"
+$(UBUNTU_BOXES): PACKAGE = "output/${TODAY}/vagrant-lxc-${@}-$(ARCH)$(BOX_SUFFIX).box"
 $(UBUNTU_BOXES):
 	@mkdir -p $$(dirname $(PACKAGE))
 	@sudo -E ./mk-debian.sh ubuntu $(@) $(ARCH) $(CONTAINER) $(PACKAGE)

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -3,7 +3,7 @@
 utils.lxc.attach() {
   cmd="$@"
   log "Running [${cmd}] inside '${CONTAINER}' container..."
-  (lxc-attach -n ${CONTAINER} -- $cmd) &>> ${LOG}
+  (lxc-attach -n ${CONTAINER} --clear-env -- $cmd) &>> ${LOG}
 }
 
 utils.lxc.start() {

--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -116,3 +116,10 @@ EOF
 else
   log "Skipping Babushka installation"
 fi
+
+if [[ $VAGRANT_LXC_PROVISION_SCRIPT ]]; then
+  dest="${ROOTFS}/tmp/${VAGRANT_LXC_PROVISION_SCRIPT##*/}"
+  cp $VAGRANT_LXC_PROVISION_SCRIPT $dest
+  chmod +x $dest
+  utils.lxc.attach "/tmp/${VAGRANT_LXC_PROVISION_SCRIPT##*/}"
+fi


### PR DESCRIPTION
Allows running a provisioner shell script inside the container when building. Useful for installing extra packages and other dependencies.
