### PR TITLE
Fix puppetlabs apt url

### DIFF
--- a/debian/install-extras.sh
+++ b/debian/install-extras.sh
@@ -60,7 +60,7 @@ if [ $PUPPET = 1 ]; then
     warn "Puppet can't be installed on Debian sid, skipping"
   else
     log "Installing Puppet"
-    wget http://apt.puppetlabs.com/puppetlabs-release-stable.deb -O "${ROOTFS}/tmp/puppetlabs-release-stable.deb" &>>${LOG}
+    wget http://apt.puppetlabs.com/puppetlabs-release-${RELEASE}.deb -O "${ROOTFS}/tmp/puppetlabs-release-stable.deb" &>>${LOG}
     utils.lxc.attach dpkg -i "/tmp/puppetlabs-release-stable.deb"
     utils.lxc.attach apt-get update
     utils.lxc.attach apt-get install puppet -y --force-yes


### PR DESCRIPTION
It looks like they've changed/removed that url?

This fix worked for me
