### PR TITLE
debian/clean.sh: cleanup /var/lib/apt/lists/*

### DIFF
--- a/debian/clean.sh
+++ b/debian/clean.sh
@@ -17,3 +17,6 @@ rm -f ${ROOTFS}/var/lib/dhcp/*
 
 log 'Removing downloaded packages...'
 utils.lxc.attach apt-get clean
+
+log 'Removing cached apt lists...'
+rm -rf ${ROOTFS}/var/lib/apt/lists/*


### PR DESCRIPTION
To prevent this from happening:
> # apt-get update
> [..]
> Reading package lists... Done
> E: Could not open file /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_main_i18n_Translation-en.diff_Index - open (2: No such file or directory)