### PR TITLE
[WIP] update the lxc configuration keywords to match version 2.1

### DIFF
--- a/conf/centos
+++ b/conf/centos
@@ -1,9 +1,9 @@
 # Taken from the oracle.common.conf.in
 # Console settings
 
-lxc.devttydir = lxc
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.dir = lxc
+lxc.tty.max = 4
+lxc.pty.max = 1024
 
 # Mount entries
 lxc.mount.auto = proc:mixed sys:ro
@@ -54,4 +54,4 @@ lxc.cgroup.devices.allow = c 10:200 rwm # /dev/net/tun
 
 # Blacklist some syscalls which are not safe in privileged
 # containers
-lxc.seccomp = /usr/share/lxc/config/common.seccomp
+lxc.seccomp.profile = /usr/share/lxc/config/common.seccomp

--- a/conf/debian
+++ b/conf/debian
@@ -6,31 +6,30 @@ lxc.mount.entry = proc proc proc nodev,noexec,nosuid 0 0
 lxc.mount.entry = sysfs sys sysfs defaults 0 0
 
 # Default console settings
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.max = 4
+lxc.pty.max = 1024
 
 # Default capabilities
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
 
 # Prevent systemd-journald from burning 100% of CPU
 # See https://wiki.debian.org/LXC#Incompatibility_with_systemd
-lxc.kmsg = 0
 lxc.autodev = 1
 
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.
-#lxc.aa_profile = unconfined
+#lxc.apparmor.profile = unconfined
 
 # To support container nesting on an Ubuntu host while retaining most of
 # apparmor's added security, use the following two lines instead.
-#lxc.aa_profile = lxc-container-default-with-nesting
+#lxc.apparmor.profile = lxc-container-default-with-nesting
 #lxc.hook.mount = /usr/share/lxc/hooks/mountcgroups
 
 # If you wish to allow mounting block filesystems, then use the following
 # line instead, and make sure to grant access to the block device and/or loop
 # devices below in lxc.cgroup.devices.allow.
-#lxc.aa_profile = lxc-container-default-with-mounting
+#lxc.apparmor.profile = lxc-container-default-with-mounting
 
 # Default cgroup limits
 lxc.cgroup.devices.deny = a

--- a/conf/debian-jessie
+++ b/conf/debian-jessie
@@ -1,6 +1,5 @@
 # support systemd as PID 1
 lxc.autodev = 1
-lxc.kmsg = 0
 
 # Default pivot location
 lxc.pivotdir = lxc_putold
@@ -10,8 +9,8 @@ lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 lxc.mount.entry = /sys/fs/fuse/connections sys/fs/fuse/connections none bind,optional 0 0
 
 # Default console settings
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.max = 4
+lxc.pty.max = 1024
 
 # Default capabilities
 lxc.cap.drop = sys_module mac_admin mac_override sys_time sys_rawio
@@ -19,17 +18,17 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time sys_rawio
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.
-#lxc.aa_profile = unconfined
+#lxc.apparmor.profile = unconfined
 
 # To support container nesting on an Ubuntu host while retaining most of
 # apparmor's added security, use the following two lines instead.
-#lxc.aa_profile = lxc-container-default-with-nesting
+#lxc.apparmor.profile = lxc-container-default-with-nesting
 #lxc.hook.mount = /usr/share/lxc/hooks/mountcgroups
 
 # If you wish to allow mounting block filesystems, then use the following
 # line instead, and make sure to grant access to the block device and/or loop
 # devices below in lxc.cgroup.devices.allow.
-#lxc.aa_profile = lxc-container-default-with-mounting
+#lxc.apparmor.profile = lxc-container-default-with-mounting
 
 # Default cgroup limits
 lxc.cgroup.devices.deny = a

--- a/conf/fedora
+++ b/conf/fedora
@@ -1,13 +1,12 @@
 # work better with systemd:
 lxc.autodev = 1
-lxc.kmsg = 0
 
 # Taken from the oracle.common.conf.in
 # Console settings
 
-lxc.devttydir = lxc
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.dir = lxc
+lxc.tty.max = 4
+lxc.pty.max = 1024
 
 # Mount entries
 lxc.mount.auto = proc:mixed sys:ro
@@ -66,4 +65,4 @@ lxc.cgroup.devices.allow = c 5:2 rwm
 
 # Blacklist some syscalls which are not safe in privileged
 # containers
-lxc.seccomp = /usr/share/lxc/config/common.seccomp
+lxc.seccomp.profile = /usr/share/lxc/config/common.seccomp

--- a/conf/ubuntu
+++ b/conf/ubuntu
@@ -6,9 +6,9 @@ lxc.mount.entry = proc proc proc nodev,noexec,nosuid 0 0
 lxc.mount.entry = sysfs sys sysfs defaults 0 0
 
 # Default console settings
-lxc.devttydir = lxc
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.dir = lxc
+lxc.tty.max = 4
+lxc.pty.max = 1024
 
 # Default capabilities
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
@@ -16,11 +16,11 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.
-#lxc.aa_profile = unconfined
+#lxc.apparmor.profile = unconfined
 
 # To support container nesting on an Ubuntu host while retaining most of
 # apparmor's added security, use the following two lines instead.
-#lxc.aa_profile = lxc-container-default-with-nesting
+#lxc.apparmor.profile = lxc-container-default-with-nesting
 #lxc.hook.mount = /usr/share/lxc/hooks/mountcgroups
 
 # Uncomment the following line to autodetect squid-deb-proxy configuration on the
@@ -30,7 +30,7 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 # If you wish to allow mounting block filesystems, then use the following
 # line instead, and make sure to grant access to the block device and/or loop
 # devices below in lxc.cgroup.devices.allow.
-#lxc.aa_profile = lxc-container-default-with-mounting
+#lxc.apparmor.profile = lxc-container-default-with-mounting
 
 # Default cgroup limits
 lxc.cgroup.devices.deny = a

--- a/conf/ubuntu-wily
+++ b/conf/ubuntu-wily
@@ -6,5 +6,4 @@
 lxc.include = /usr/share/lxc/config/ubuntu.common.conf
 
 # settings for systemd with PID 1:
-lxc.kmsg = 0
 lxc.autodev = 1

--- a/conf/ubuntu-xenial
+++ b/conf/ubuntu-xenial
@@ -6,8 +6,7 @@
 lxc.include = /usr/share/lxc/config/ubuntu.common.conf
 
 # settings for systemd with PID 1:
-lxc.kmsg = 0
 lxc.autodev = 1
 # allow unconfined and incomplete
-lxc.aa_profile = unconfined
-lxc.aa_allow_incomplete = 1
+lxc.apparmor.profile = unconfined
+lxc.apparmor.allow_incomplete = 1


### PR DESCRIPTION
Hi there,

I just bumped into some problem when using lxc >= 2.1
this is a first quick fix applying lxc-update-config -c on the config directory and removing kmsg key.
Then  I was able to setup some xenial basebox which worked fine with lxc >=2.1

This is work in progress, and I would rather check the version of the lxc package before running this configuration. I do not know about the backward compatibility for people trying to use the basebox with some lxc < 2.1

Regards
-- 
Eric